### PR TITLE
Fix issue #110

### DIFF
--- a/guide/src/main/java/com/app/hubert/guide/core/Controller.java
+++ b/guide/src/main/java/com/app/hubert/guide/core/Controller.java
@@ -261,7 +261,7 @@ public class Controller {
             });
         }
 
-        if (v4Fragment != null) {
+        if (v4Fragment != null && v4Fragment.isAdded()) {
             android.support.v4.app.FragmentManager v4Fm = v4Fragment.getChildFragmentManager();
             V4ListenerFragment v4ListenerFragment = (V4ListenerFragment) v4Fm.findFragmentByTag(LISTENER_FRAGMENT);
             if (v4ListenerFragment == null) {


### PR DESCRIPTION
When we call getChildFragmentManager, if fragment wasn't added (mHost == null), it will throw IllegalStateException "Fragment has not been attached yet".