### PR TITLE
修复showPreviewPage和RelativeGuide的初始化监听问题

### DIFF
--- a/guide/src/main/java/com/app/hubert/guide/core/Controller.java
+++ b/guide/src/main/java/com/app/hubert/guide/core/Controller.java
@@ -157,7 +157,7 @@ public class Controller {
      * 显示当前引导页的前一页
      */
     public void showPreviewPage() {
-        showPage(--current);
+        showPage(current - 1);
     }
 
     /**

--- a/guide/src/main/java/com/app/hubert/guide/model/RelativeGuide.java
+++ b/guide/src/main/java/com/app/hubert/guide/model/RelativeGuide.java
@@ -11,6 +11,7 @@ import android.widget.FrameLayout;
 
 import com.app.hubert.guide.core.Controller;
 import com.app.hubert.guide.util.LogUtil;
+import com.app.hubert.guide.listener.OnLayoutInflatedListener;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -52,9 +53,17 @@ public class RelativeGuide {
     public int padding;
     public int gravity;
 
+    private OnLayoutInflatedListener mListener;
+
     public RelativeGuide(@LayoutRes int layout, @LimitGravity int gravity) {
         this.layout = layout;
         this.gravity = gravity;
+    }
+
+    public RelativeGuide(@LayoutRes int layout, @LimitGravity int gravity , OnLayoutInflatedListener listener) {
+        this.layout = layout;
+        this.gravity = gravity;
+        this.mListener = listener;
     }
 
     /**
@@ -133,6 +142,9 @@ public class RelativeGuide {
      * @param controller controller
      */
     protected void onLayoutInflated(View view, Controller controller) {
-        //do nothing
+        // 调用自身onLayoutInflated listener
+        if (mListener != null){
+            mListener.onLayoutInflated(view,controller);
+        }
     }
 }


### PR DESCRIPTION
```
public void showPreviewPage() {
        showPage(--current);
}
```
直接更改current的值，导致showPage检测current == position为true，无法正确运行

RelativeGuide自身没有添加OnLayoutInflatedListener，为GuidePage添加的OnLayoutInflatedListener并未在RelativeGuide调用。
因此为RelativeGuide新增OnLayoutInflatedListener